### PR TITLE
Feedback functionality from openai

### DIFF
--- a/shellhacks2023/Models/AnswerBatchRequest.cs
+++ b/shellhacks2023/Models/AnswerBatchRequest.cs
@@ -1,0 +1,11 @@
+﻿namespace shellhacks2023.Models
+{
+    public class AnswerBatchRequest
+    {
+        public Dictionary<Guid, string>   Answers { get; set; }
+        public bool? SaveAnswer { get; set; } = true;
+        public Guid? StudentId { get; set; }
+        public string? Model { get; set; } = "GPT-4";
+
+    }
+}


### PR DESCRIPTION
solves #13 

Added:
- Added controller that takes a dict of question_id and answer text, it gets the questions form the database injects questions and answers into a prompt and then queries openai for wether they're correct or not
- Answers are returned in a question_id and feedback dictionary
- BatchAnswerRequest model includes other parameters such as studentid, model and save answer, they're nullable so they shouldn't be an issue, but they're useful if we eventually decide to implement save functionality